### PR TITLE
Vanilla 1.17 (Temporary)

### DIFF
--- a/mc-server/Dockerfile.template
+++ b/mc-server/Dockerfile.template
@@ -1,8 +1,5 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:latest
 
-# \/ If you want to use java 8 delete the # in front of the line below and add a # in front of the first line \/
-# FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-openjdk:8-jdk-stretch
-
 ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
 RUN install_packages wget jq
@@ -13,7 +10,7 @@ COPY start.sh /usr/src/
 
 ADD https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-aarch64_bin.tar.gz /opt/
 
-RUN tar -zxf /openjdk-16.0.1_linux-aarch64_bin.tar.gz -C /opt/
+RUN tar -zxf /opt/openjdk-16.0.1_linux-aarch64_bin.tar.gz -C /opt/
 
 RUN chmod +x /usr/src/start.sh
 

--- a/mc-server/Dockerfile.template
+++ b/mc-server/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-openjdk:latest-buster
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:latest
 
 # \/ If you want to use java 8 delete the # in front of the line below and add a # in front of the first line \/
 # FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-openjdk:8-jdk-stretch
@@ -10,6 +10,10 @@ RUN install_packages wget jq
 COPY . /
 
 COPY start.sh /usr/src/
+
+ADD https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-aarch64_bin.tar.gz /opt/
+
+RUN tar -zxf /openjdk-16.0.1_linux-aarch64_bin.tar.gz -C /opt/
 
 RUN chmod +x /usr/src/start.sh
 

--- a/mc-server/start.sh
+++ b/mc-server/start.sh
@@ -1,17 +1,4 @@
 #!/usr/bin/env bash
-# Get all the information about the latest
-get_latest_server() {
-  MC_VERSION=$(curl -s "https://papermc.io/api/v2/projects/paper/" | jq -r -e .versions[-1])
-  LATEST_BUILD=$(curl -s "https://papermc.io/api/v2/projects/paper/versions/$MC_VERSION" | jq -r -e .builds[-1])
-  SERVER_JAR_FILENAME=$(curl -s "https://papermc.io/api/v2/projects/paper/versions/$MC_VERSION/builds/$LATEST_BUILD/" | jq -r -e .downloads.application.name)
-  SERVER_JAR_SHA256=$(curl -s "https://papermc.io/api/v2/projects/paper/versions/$MC_VERSION/builds/$LATEST_BUILD/" | jq -r -e .downloads.application.sha256)
-  SERVER_JAR_URL="https://papermc.io/api/v2/projects/paper/versions/$MC_VERSION/builds/$LATEST_BUILD/downloads/$SERVER_JAR_FILENAME"
-
-  printf "%s\n" "Downloading $MC_VERSION build $LATEST_BUILD..."
-
-  echo "$SERVER_JAR_SHA256 paper.jar" > papersha256.txt
-  wget --quiet -O paper.jar -T 60 $SERVER_JAR_URL
-}
 
 # Wait for working internet access here
 wget --quiet --spider https://papermc.io 2>&1
@@ -33,6 +20,7 @@ if [[ -z "$RAM" ]]; then
   RAM="1G"
 fi
 
+
 printf "%s\n" "Setting device hostname to: $DEVICE_HOSTNAME"
 
 curl -s -X PATCH --header "Content-Type:application/json" \
@@ -42,38 +30,26 @@ curl -s -X PATCH --header "Content-Type:application/json" \
 # Download a server JAR if we don't already have a valid one
 # And copy the server files into the directory on first run
 printf "\n\n%s\n\n" "Starting balenaMinecraftServer..."
-if [[ -z "$ENABLE_UPDATE" ]]; then
-  if [[ ! -e "/servercache/copied.txt" ]]; then
-    printf "%s\n" "Copying config"
-    # Copy the serverfiles to the volume
-    cp -R /serverfiles /usr/src/
-    # Mark this is done and store the SHA256 we're using
-    touch /servercache/copied.txt
-  else
-    printf "%s\n" "Config already copied"
-  fi
 
-  cd /usr/src/serverfiles/
-
-  printf "%s" "Checking server JAR... "
-  # Check to see if we have a server jar, and if we do, is it valid?
-  if [[ ! -e "paper.jar" ]]; then
-    printf "%s\n" "No server JAR found."
-    get_latest_server
-  fi
-
-  # We have a paper.jar, is it valid?
-  if [[ $(sha256sum -c papersha256.txt --status 2>/dev/null) -eq 1 || ! -e "papersha256.txt" ]]; then
-    printf "%s\n" "Server JAR not valid."
-    get_latest_server
-  else
-    printf "%s\n" "Found a valid server file. It's called: $(ls *.jar). Use ENABLE_UPDATE to update."
-  fi
+if [[ ! -e "/servercache/copied.txt" ]]; then
+  printf "%s\n" "Copying config"
+  # Copy the serverfiles to the volume
+  cp -R /serverfiles /usr/src/
+  # Mark this is done and store the SHA256 we're using
+  touch /servercache/copied.txt
 else
-# But also allow forcing of an update
-  printf "%s\n" "Forcing server update"
-  get_latest_server
+  printf "%s\n" "Config already copied"
 fi
+
+cd /usr/src/serverfiles/
+
+printf "%s" "Checking server JAR... "
+# Check to see if we have a server jar, and if we do, is it valid?
+if [[ ! -e $JAR_FILE ]]; then
+  printf "%s\n" "No server JAR found."
+  exit 1
+fi
+
 
 if [[ ! -z "$ENABLE_CONFIG_UPDATE" ]]; then
   # Copy the serverfiles to the volume
@@ -86,7 +62,7 @@ cd /usr/src/serverfiles/
 
 # Do that forever
 printf "%s\n" "Starting JAR file with: $RAM of RAM"
-java -Xms$RAM -Xmx$RAM -jar $JAR_FILE
+/opt/jdk-16.0.1/bin/java -Xms$RAM -Xmx$RAM -jar $JAR_FILE
 
 # Don´t overload the server if the start fails 
 sleep 10

--- a/mc-server/start.sh
+++ b/mc-server/start.sh
@@ -13,7 +13,7 @@ if [[ -z "$DEVICE_HOSTNAME" ]]; then
 fi
 
 if [[ -z "$JAR_FILE" ]]; then
-  JAR_FILE="paper.jar"
+  JAR_FILE="server.jar"
 fi
 
 if [[ -z "$RAM" ]]; then
@@ -46,8 +46,10 @@ cd /usr/src/serverfiles/
 printf "%s" "Checking server JAR... "
 # Check to see if we have a server jar, and if we do, is it valid?
 if [[ ! -e $JAR_FILE ]]; then
-  printf "%s\n" "No server JAR found."
-  exit 1
+  printf "%s\n" "No server JAR found. Downloading from official website"
+  wget -O server.jar -T 15 -c https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
+  JAR_FILE="server.jar"
+  printf "%s\n" "Download complete"
 fi
 
 


### PR DESCRIPTION
# This is a dummy PR and its not to be merged
(This should not be used as a final and definitive version because paper and debian-java image is more optimized to run a minecraft server)
While we wait for version 1.17 of paper and the java 16 image of balenalib I went ahead customized the repo to be able to run the 1.17.


## Changes 
* Using debian base image instead of the debian-java
* Change mc-server/start.sh to fetch 1.17 from the official website when not provided locally
