### PR TITLE
Update mc-server base image to contain java 17

### DIFF
--- a/mc-server/Dockerfile.template
+++ b/mc-server/Dockerfile.template
@@ -1,8 +1,8 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:latest
+FROM balenalib/%%BALENA_MACHINE_NAME%%-openjdk:17-latest
 
 ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
-RUN install_packages wget jq openjdk-17-jre
+RUN install_packages wget jq
 
 COPY . /
 


### PR DESCRIPTION
## Change-type: minor

This PR changes the `mc-server` container base image to already have openjdk-17 installed. Imo it's more clean and safe this way.
The image which was changed to is [balenalib/raspberrypi4-64-openjdk:17-latest](https://hub.docker.com/layers/balenalib/raspberrypi4-64-openjdk/17-latest/images/sha256-738f29f53cc36de38af2659fc2c9621c6200ff911c6bc3e08418beed57f97585?context=explore).